### PR TITLE
Offers to create the default $DOCROOT for the user if it doesn't exist

### DIFF
--- a/bin/nepenthes
+++ b/bin/nepenthes
@@ -8,7 +8,13 @@ test_docroot() {
     if [[ ! -d $DOCROOT ]]; then
         echo "ERROR: $DOCROOT is specified as your document root but that directory does not exist."
         echo "Either create it or modify the \$DOCROOT variable in $0"
-        exit 1
+        echo "Would you like me to create $DOCROOT for you(yes/no)?"
+        read makedir
+        if [[ $makedir == yes ]]; then 
+          $(mkdir -p $DOCROOT)
+        else
+          exit 1
+        fi
         $SHELL
     fi
 }


### PR DESCRIPTION
This change just offers to create the default $DOCROOT for lazy people like me who would rather type "yes" than type "mkdir ~/Documents/nepenthes"