### PR TITLE
use local conf file by default, abstract EDITOR choice

### DIFF
--- a/bin/nepenthes
+++ b/bin/nepenthes
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-DOCROOT="$HOME/Documents/nepenthes"
-TODAY=`date "+%Y%m%d"`
-END=`date -d "+7 days" "+%Y%m%d"`
-
 test_docroot() {
     if [[ ! -d $DOCROOT ]]; then
         echo "ERROR: $DOCROOT is specified as your document root but that directory does not exist."
@@ -43,8 +39,22 @@ newentry() {
     echo -e `date "+%I:%M %p"` "-" `date "+%a, %b %d"` "\n" >> $DOCROOT/latest.nep
 }
 
-test_docroot
 
+if [ -e $HOME/.local/share/nepenthes.conf ]; then
+    source $HOME/.local/share/nepenthes.conf 
+else
+    DOCROOT="$HOME/Documents/nepenthes"
+    TODAY=`date "+%Y%m%d"`
+    END=`date -d "+7 days" "+%Y%m%d"`
+    EDITOR='vim "+normal G$" +star'
+fi
+
+if [ $AUTOCREATE == 1 -a ! -d $DOCROOT ]; then
+    mkdir $DOCROOT
+else
+    test_docroot
+fi
+    
 if [ ! -f "$DOCROOT/latest.nep" ]; then
     echo "$DOCROOT/latest.nep doesn't exist. What is the date of your next handoff meeting?"
     read -p "Format YYYYMMDD: " END
@@ -68,4 +78,4 @@ fi
 
 newentry
 
-vim "+normal G$" +star $DOCROOT/latest.nep
+$EDITOR $DOCROOT/latest.nep 

--- a/dot-local/share/nepenthes.conf-example
+++ b/dot-local/share/nepenthes.conf-example
@@ -1,0 +1,5 @@
+DOCROOT="$HOME/notes"
+TODAY=`date "+%Y%m%d"`
+END=`date -d "+7 days" "+%Y%m%d"`
+AUTOCREATE=1 #0 for false
+EDITOR=emacs

--- a/dot-local/share/nepenthes.conf-example
+++ b/dot-local/share/nepenthes.conf-example
@@ -2,4 +2,3 @@ DOCROOT="$HOME/notes"
 TODAY=`date "+%Y%m%d"`
 END=`date -d "+7 days" "+%Y%m%d"`
 AUTOCREATE=1 #0 for false
-EDITOR=emacs


### PR DESCRIPTION
I added a conf file allowing users to override default DOCROOT and other vars.

Also added a sample conf file.

Also abstracted EDITOR. Should respect user's env, or the user can choose one in their conf file. I have EDITOR set in so many places at this point, it's hard for me to test, but it should work...