### PR TITLE
config parser

### DIFF
--- a/bin/nepenthes
+++ b/bin/nepenthes
@@ -154,7 +154,7 @@ else
     # or set to these hardcoded defaults
     `$DEBUG` && echo "No config file found."
     DOCROOT="$HOME/Documents/nepenthes"
-    TODAY="`date "+%Y%m%d"`"
+    TODAY=`date "+%Y%m%d"`
     END=`date -d "+7 days" "+%Y%m%d"`
     EDITOR='vim "+normal G$" +star'
 fi

--- a/bin/nepenthes
+++ b/bin/nepenthes
@@ -1,5 +1,54 @@
 #!/bin/bash
 
+version() {
+    echo "$1, version ${VERSION}, GPLv3"
+}
+
+helper() {
+    echo "nepenthes <project>"
+    echo " "
+    echo "--docroot, -d  = set document path for notes"
+    echo "--today, -t    = set today's date"
+    echo "--end, -e      = set end date"
+    echo "--auto, -a     = autocreate note file"
+    echo "--timezone, -z = set timezone"
+    echo "--config, -c   = configuration file to use"
+    echo "--config-list  = configuration file to use"
+    echo " "
+    echo "--which, -w    = print --version and exit"
+    echo "--verbose, -v  = print --debug messages"
+    echo "--help, -h     = print this --help message and exit"
+    echo " "
+}
+
+figparse() {
+    # after command line args have been processed,
+    # parse config file for any remaining defaults
+
+    for SECTION in "${PROJECT}"; do
+    if [ ! ${DOCROOT} ]; then 
+	DOCROOT=`sed -nr "/^\[$SECTION\]/ { :l /^DOCROOT[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" "${CONFIG}"`;fi
+    if [ ! $TZ ]; then
+	export TZ=`sed -nr "/^\[$SECTION\]/ { :l /^TZ[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" "${CONFIG}"`;fi
+    if [ ! $TODAY ]; then 
+	TODAY=`sed -nr "/^\[$SECTION\]/ { :l /^TODAY[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" "${CONFIG}"`;fi
+    if [ ! $END ]; then 
+	END=`sed -nr "/^\[$SECTION\]/ { :l /^END[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" "${CONFIG}"`;fi
+    if [ ! ${AUTOCREATE} ]; then
+	AUTOCREATE=`sed -nr "/^\[$SECTION\]/ { :l /^AUTOCREATE[ ]*=/ { s/.*=[ ]*//; p; q;}; n; b l;}" "${CONFIG}"`;fi
+    done
+}
+
+figlist() {
+    # list available config blocks
+    
+    if [ x"${CONFIG}" != "x" ]; then
+	egrep '\[.*\]' "${CONFIG}" | tail -n +1
+    else
+	echo "No config file found."
+    fi 
+}
+
 test_docroot() {
     if [[ ! -d $DOCROOT ]]; then
         echo "ERROR: $DOCROOT is specified as your document root but that directory does not exist."
@@ -32,29 +81,93 @@ validate_date() {
 }
 
 newfile() {
-    echo -e "START $TODAY\nEND $END\n" > $DOCROOT/latest.nep
+    echo -e "\nSTART $TODAY\nEND $END\n" > $DOCROOT/latest.nep
 }
 
 newentry() {
     echo -e `date "+%I:%M %p"` "-" `date "+%a, %b %d"` "\n" >> $DOCROOT/latest.nep
 }
 
+VERSION=${VERSION:-18.03.27}
 
-if [ -e $HOME/.local/share/nepenthes.conf ]; then
-    source $HOME/.local/share/nepenthes.conf 
+## These values can be overridden
+## by CONFIG, ENV, or as --options
+SED=`which sed`  # example: $ SED=gsed nepenthes
+DEBUG=false
+CONFIG="$HOME/.local/share/nepenthes.conf"
+
+while [ True ]; do
+if [ "$1" = "--config-list" ]; then
+    figlist
+    exit 0
+elif [ "$1" = "--docroot" -o "$1" = "-d" ]; then
+    DOCROOT="$2"
+    shift 2
+elif [ "$1" = "--today" -o "$1" = "-t" ]; then
+    TODAY="$2"
+    shift 2
+elif [ "$1" = "--end" -o "$1" = "-e" ]; then
+    END="$2"
+    shift 2
+elif [ "$1" = "--auto" -o "$1" = "-a" ]; then
+    AUTOCREATE=1
+    shift 1
+elif [ "$1" = "--timezone" -o "$1" = "-z" ]; then
+    TIMEZONE="$2"
+    shift 2
+elif [ "$1" = "--config" -o "$1" = "-c" ]; then
+    CONFIG="$2"
+    shift 2
+elif [ "$1" = "--version" -o "$1" = "-w" -o "$1" = "--which" ]; then
+    version
+    exit 0
+elif [ "$1" = "--help" -o "$1" = "-h" ]; then
+    version
+    helper
+    exit 0
+elif [ "$1" = "--debug" -o "$1" = "--verbose" -o "$1" = "-v" ]; then
+    DEBUG=true
+    shift 1
 else
+    break
+fi
+done
+
+# get project name or set to default
+if [ x"${1}" == x ]; then
+    `$DEBUG` && echo "Using default project."
+    PROJECT=default
+else
+    `$DEBUG` && echo "Using project $1"
+    PROJECT=${1}
+fi
+
+if [ -r "${CONFIG}" ]; then
+    # get remaining unset values from config
+    `$DEBUG` && echo "Found config file, using" ${PROJECT}
+    figparse "${PROJECT}"
+    `$DEBUG` && echo "Today set to ${TODAY}"
+    `$DEBUG` && echo "Docroot set to ${DOCROOT}"
+    `$DEBUG` && echo "Editor set to ${EDITOR}"
+    `$DEBUG` && echo "Autocreate set to ${AUTOCREATE}"
+else
+    # or set to these hardcoded defaults
+    `$DEBUG` && echo "No config file found."
     DOCROOT="$HOME/Documents/nepenthes"
-    TODAY=`date "+%Y%m%d"`
+    TODAY="`date "+%Y%m%d"`"
     END=`date -d "+7 days" "+%Y%m%d"`
     EDITOR='vim "+normal G$" +star'
 fi
 
-if [ $AUTOCREATE == 1 -a ! -d $DOCROOT ]; then
-    mkdir $DOCROOT
+if [ "${AUTOCREATE}" -eq 1 -a ! -d "${DOCROOT}" ]; then
+    # create docroot dir path. if it already exists, continue.
+    `$DEBUG` && echo "Autocreating docroot..."
+    mkdir -p $DOCROOT || true
 else
+    # no autocreate, so does docroot exist?
     test_docroot
 fi
-    
+
 if [ ! -f "$DOCROOT/latest.nep" ]; then
     echo "$DOCROOT/latest.nep doesn't exist. What is the date of your next handoff meeting?"
     read -p "Format YYYYMMDD: " END

--- a/dot-local/share/nepenthes.conf-example
+++ b/dot-local/share/nepenthes.conf-example
@@ -1,5 +1,9 @@
-DOCROOT="$HOME/notes"
-#TZ='America/New_York' # Optional
-TODAY=`TZ=$TZ date "+%Y%m%d"`
-END=`date -d "+7 days" "+%Y%m%d"`
-AUTOCREATE=1 #0 for false
+[default]
+DOCROOT = /home/klaatu/notes
+TZ = 'America/New_York'
+AUTOCREATE = 1 
+
+[comp112]
+DOCROOT = /home/klaatu/school/lecture
+TZ = 'Pacific/Auckland'
+AUTOCREATE = 1 


### PR DESCRIPTION
Config files can now have separate blocks. 

The ``[default]`` block causes nepenthes to act as it always has. If run with no arguments, then nepenthes launches with default location, default editor, timezone, etc:

    $ nepenthes

User can add more blocks, such as ``[comp112]``, with a different docroot, different editor, timezone, autocreate setting, and so on. To use this config block instead:

    $ nepenthes comp112

User can have as many config blocks as desired, meaning that nepenthes can now manage several unique "notebooks" full of notes that are specific to a given project.


Also, I have had problems with $VARIABLES in the config file (they don't get expanded, as it turns out; I'd never noticed because my file location was the same as the hardcoded default in nepenthes). So no mare vars in the config file. The example config file has been updated to reflect this.
